### PR TITLE
Add cmake, capnproto to build inputs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -22,5 +22,7 @@ in
     buildInputs = with nixpkgs; [
       libllvm
       lcov
+      cmake
+      capnproto
     ];
   }


### PR DESCRIPTION
Hello!

I don't know if this repository is still maintained, since the last commit is from two years ago, but it just helped me to build Bitcoin Core, so thank you!

I just had to add `cmake` and `capnproto` as build inputs since Bitcoin Core replaced the Autotools-based build system with a new CMake-based build system in https://github.com/bitcoin/bitcoin/pull/30454.

Without `cmake` and `capnproto`, running `cmake -B build` fails.

I used commit [`d0f6d995`](https://github.com/bitcoin/bitcoin/commit/d0f6d9953a15d7c7111d46dcb76ab2bb18e5dee3) from Bitcoin Core to test this.

(I don't know if this is the best way to fix this since I'm still quite new to writing `shell.nix` files.)