### PR TITLE
Use nixos-25.11 to update to clang19Stdenv

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 { nixpkgs ? import builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/057f9aecfb71c4437d2b27d3323df7f93c010b7e.tar.gz";
-    sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
+    url = "https://github.com/NixOS/nixpkgs/archive/871b9fd269ff6246794583ce4ee1031e1da71895.tar.gz";
+    sha256 = "1zn1lsafn62sz6azx6j735fh4vwwghj8cc9x91g5sx2nrg23ap9k";
   } {}
 , withGui ? false
 , withWallet ? true
@@ -9,7 +9,7 @@
 }:
 {
   bitcoin = with nixpkgs; callPackage ./bitcoin.nix {
-    stdenv = clang16Stdenv;
+    stdenv = clang19Stdenv;
     inherit (qt5) qtbase qttools wrapQtAppsHook;
     inherit (darwin) autoSignDarwinBinariesHook;
     python3 = python3.withPackages (p: with p; [

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { nixpkgs ? import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/057f9aecfb71c4437d2b27d3323df7f93c010b7e.tar.gz";
-    sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
+    url = "https://github.com/NixOS/nixpkgs/archive/871b9fd269ff6246794583ce4ee1031e1da71895.tar.gz";
+    sha256 = "1zn1lsafn62sz6azx6j735fh4vwwghj8cc9x91g5sx2nrg23ap9k";
   }) {}
 , withGui ? false
 , withWallet ? true
@@ -13,7 +13,7 @@ let
   };
 in
   nixpkgs.mkShell.override {
-    stdenv = nixpkgs.clang16Stdenv; # required for fuzzing; must be recent version
+    stdenv = nixpkgs.clang19Stdenv; # required for fuzzing; must be recent version
   } {
     inherit (main.bitcoin) configureFlags;
     inputsFrom = [


### PR DESCRIPTION
Hello!

This fixes #5 by updating nixpkgs to nixos-25.11 ([`871b9fd`](https://github.com/NixOS/nixpkgs/commit/871b9fd269ff6246794583ce4ee1031e1da71895)), and then using `clang19Stdenv` instead of `clang16Stdenv`.

I couldn't use `clang17Stdenv` because [it's already deprecated](https://github.com/NixOS/nixpkgs/blob/871b9fd269ff6246794583ce4ee1031e1da71895/pkgs/top-level/aliases.nix#L420).

I was able to build Bitcoin Core ([`f7e0c3d`](https://github.com/bitcoin/bitcoin/commit/f7e0c3d3d370a4e5b4060fefcb9e8d83e2533bbc))  with `clang18Stdenv`, but I thought it makes sense to update to the latest available version, which is `clang19Stdenv`.